### PR TITLE
Create central-ingress.yaml

### DIFF
--- a/ingress/contour/central-ingress.yaml
+++ b/ingress/contour/central-ingress.yaml
@@ -1,0 +1,14 @@
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: central
+  namespace: stackrox
+spec:
+  tcpproxy:
+    services:
+    - name: central
+      port: 443
+  virtualhost:
+    fqdn: central.blah.blar.tld
+    tls:
+      passthrough: true


### PR DESCRIPTION
Working configuration for contour ingress for remote sensors to the Central API. Contour does proxy protocol termination, tls passthrough and tcp routing.