### PR TITLE
add nginx proxy body size annotation

### DIFF
--- a/ingress/nginx/central-nginx-encrypt-ingress.yaml
+++ b/ingress/nginx/central-nginx-encrypt-ingress.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/backend-protocol: "GRPCS"
+    nginx.ingress.kubernetes.io/proxy-body-size: "2m"
   name: central-ingress
   namespace: stackrox
 spec:


### PR DESCRIPTION
Default nginx proxy body size causes errors when deploying sensor from other clusters.