### PR TITLE
Reconcile StackRox policy with input file

### DIFF
--- a/util-scripts/policy-update/README.md
+++ b/util-scripts/policy-update/README.md
@@ -1,0 +1,14 @@
+# Sync StackRox Policy
+
+This script consumes a policy definition json file and either creates or updates and existing StackRox policy of the same name if there are any changes
+
+**Required Environment Vars:**
+* `ROX_ENDPOINT` - Host for StackRox central (central.example.com)
+* `ROX_API_TOKEN` - Token data from [StackRox API token](https://help.stackrox.com/docs/use-the-api/#generate-an-access-token)
+
+**Required Argument:**
+* `$1 = path/to/policy_definition.json`
+
+**Usage**
+`./policy-update.sh /policies/root-user.json`
+

--- a/util-scripts/policy-update/README.md
+++ b/util-scripts/policy-update/README.md
@@ -9,6 +9,9 @@ This script consumes a policy definition json file and either creates or updates
 **Required Argument:**
 * `$1 = path/to/policy_definition.json`
 
+**Required Tools:**
+* `jq` is used by this script and must be installed.  Installation instructions for various platforms can be found [here](https://stedolan.github.io/jq/download/)
+
 **Usage**
 `./policy-update.sh /policies/root-user.json`
 

--- a/util-scripts/policy-update/policy-update.sh
+++ b/util-scripts/policy-update/policy-update.sh
@@ -67,7 +67,7 @@ fi
 id=$(echo $get_response | jq -r '.policies[0].id')
 echo $id
 
-#Compare the exiting policy to the new definition
+# Compare the existing policy to the new definition
 echo "Policy with name: ${name}, already exists. Comparing policy defintions"
 current_policy=$(curl_get_policy_details "${id}" | jq 'del(. | .id, .lastUpdated, .policyVersion, .SORTName, .SORTLifecycleStage)' )
 echo ""

--- a/util-scripts/policy-update/policy-update.sh
+++ b/util-scripts/policy-update/policy-update.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+# Usage, ./policy-update.sh policy.json
+
+if [[ -z "${ROX_ENDPOINT}" ]]; then
+  echo >&2 "ROX_ENDPOINT must be set"
+  exit 1
+fi
+
+if [[ -z "${ROX_API_TOKEN}" ]]; then
+  echo >&2 "ROX_API_TOKEN must be set"
+  exit 1
+fi
+
+if [[ -z "$1" ]]; then
+  echo >&2 "usage: create-csv.sh <output filename>"
+  exit 1
+fi
+
+input_file_path="$1"
+
+input=$(cat $PWD/$1)
+
+echo $input | jq type
+RES=$?
+if [ $RES != 0 ]; then
+    exit 1
+fi
+
+input_data()
+{
+    cat <<EOF
+    $input
+EOF
+}
+
+
+function curl_get_policy() {
+  curl -sk -H "Authorization: Bearer ${ROX_API_TOKEN}" "https://${ROX_ENDPOINT}/v1/policies?query=Policy%3A$1"
+}
+
+function curl_get_policy_details() {
+    curl -sk -H "Authorization: Bearer ${ROX_API_TOKEN}" "https://${ROX_ENDPOINT}/v1/policies/$1"
+}
+
+function curl_post_policy() {
+  curl -sk -XPOST -H "Authorization: Bearer ${ROX_API_TOKEN}" "https://${ROX_ENDPOINT}/v1/policies" --data "$(input_data)"
+}
+
+function curl_put_policy() {
+  curl -sk -XPUT -H "Authorization: Bearer ${ROX_API_TOKEN}" "https://${ROX_ENDPOINT}/v1/policies/$1" --data "$(input_data)"
+}
+
+# Get policy Name from input file
+name=$(echo $input | jq -r '.name')
+
+get_response="$(curl_get_policy "${name}")"
+
+# If no results, then create policy
+if [[ "$(echo "${get_response}" | jq '.policies | length')" == "0" ]]; then
+    echo "Policy With name: ${name}, does not exist. Creating new policy"
+    res="$(curl_post_policy)"
+    echo $res
+    exit
+fi
+
+# Get policy ID from query response
+id=$(echo $get_response | jq -r '.policies[0].id')
+echo $id
+
+#Compare the exiting policy to the new definition
+echo "Policy with name: ${name}, already exists. Comparing policy defintions"
+current_policy=$(curl_get_policy_details "${id}" | jq 'del(. | .id, .lastUpdated, .policyVersion, .SORTName, .SORTLifecycleStage)' )
+echo ""
+echo "Current Policy:"
+echo ""
+echo $current_policy
+echo "====================================="
+
+# Need to strip: id, lastUpdated, policyVersion
+new_policy="$(echo $input | jq 'del(. | .id, .lastUpdated, .policyVersion, .SORTName, .SORTLifecycleStage)')"
+echo ""
+echo "New Policy:"
+echo ""
+echo $new_policy
+echo "====================================="
+
+same=$(jq --argjson a "${new_policy}" --argjson b "${current_policy}" -n '($a | (.. | arrays) |= sort) as $a | ($b | (.. | arrays) |= sort) as $b | $a == $b')
+
+echo "$same"
+if [[ "$same" == "false" ]]; then
+    echo "Policy changes detected, importing new policy spec"
+    res=$(curl_put_policy $id)
+    echo $res
+else
+    echo "No policy changes detected"
+fi


### PR DESCRIPTION
   This script is for managing stackrox policies in a gitops model. The idea is to save
    policy definition files in VCS and run this script agains the policy definition files
    when they are merged into master.