### PR TITLE
Update rox-image-scan-task.yml

### DIFF
--- a/ci/Tekton/Tasks/rox-image-scan-task.yml
+++ b/ci/Tekton/Tasks/rox-image-scan-task.yml
@@ -35,6 +35,7 @@ spec:
       script: |
         #!/usr/bin/env bash
         set +x
+        export NO_COLOR="True"
         curl -k -L -H "Authorization: Bearer $ROX_API_TOKEN" https://$ROX_CENTRAL_ENDPOINT/api/cli/download/roxctl-linux --output ./roxctl  > /dev/null; echo "Getting roxctl" 
         chmod +x ./roxctl > /dev/null
         ./roxctl image scan --insecure-skip-tls-verify -e $ROX_CENTRAL_ENDPOINT --image $(params.image) --format $(params.output_format) 


### PR DESCRIPTION
Today, Tekton doesn't properly parse the colors in the `roxctl image scan` output, leaving raw control characters in the output.  Setting NO_COLOR forces `roxctl` to output in monochrome.