### PR TITLE
Added tag to centos images in Tekton pipelines tasks

### DIFF
--- a/ci/Tekton/Tasks/rox-deployment-check-task.yml
+++ b/ci/Tekton/Tasks/rox-deployment-check-task.yml
@@ -24,7 +24,7 @@ spec:
       mountPath: /deployfile
   steps:
     - name: rox-deployment-check
-      image: centos
+      image: centos:8
       env:
         - name: ROX_API_TOKEN
           valueFrom:

--- a/ci/Tekton/Tasks/rox-image-check-task.yml
+++ b/ci/Tekton/Tasks/rox-image-check-task.yml
@@ -19,7 +19,7 @@ spec:
         description: Output of `roxctl image check`
   steps:
     - name: rox-image-check
-      image: centos
+      image: centos:8
       env:
         - name: ROX_API_TOKEN
           valueFrom:

--- a/ci/Tekton/Tasks/rox-image-scan-task.yml
+++ b/ci/Tekton/Tasks/rox-image-scan-task.yml
@@ -20,7 +20,7 @@ spec:
       default: json
   steps:
     - name: rox-image-scan
-      image: centos
+      image: centos:8
       env:
         - name: ROX_API_TOKEN
           valueFrom:


### PR DESCRIPTION
Added a tag to image reference in Tekton Pipelines examples.

The tasks create pods that run the `roxctl` cli on `centos` images with the `latest` tag.

The pods fail to create when the `Latest tag` system policy is enforced on the `Deploy` lifecycle (The admission controller does not allow the creation of the task pods) in Stackrox.

Adding a tag to the `centos` image fixes the issue.