### PR TITLE
Store scan pass/fail in result for use in downstream tasks

### DIFF
--- a/ci/Tekton/Tasks/rox-image-check-task.yml
+++ b/ci/Tekton/Tasks/rox-image-check-task.yml
@@ -15,8 +15,8 @@ spec:
       type: string
       description: Full name of image to scan (example -- gcr.io/rox/sample:5.0-rc1)
   results:
-      - name: check_output
-        description: Output of `roxctl image check`
+      - name: check_passed
+        description: Whether the task passed or failed, "true" for a pass, "false" for a fail.
   steps:
     - name: rox-image-check
       image: centos:8
@@ -36,4 +36,9 @@ spec:
         set +x
         curl -k -L -H "Authorization: Bearer $ROX_API_TOKEN" https://$ROX_CENTRAL_ENDPOINT/api/cli/download/roxctl-linux --output ./roxctl  > /dev/null; echo "Getting roxctl"
         chmod +x ./roxctl  > /dev/null
-        ./roxctl image check --insecure-skip-tls-verify -e $ROX_CENTRAL_ENDPOINT --image $(params.image) 
+        if ./roxctl image check --insecure-skip-tls-verify -e $ROX_CENTRAL_ENDPOINT --image $(params.image); then
+          echo -n "true" > $(results.check_passed.path)
+        else
+          echo -n "false" > $(results.check_passed.path)
+        fi
+        cd .

--- a/ci/Tekton/Tasks/rox-image-scan-task.yml
+++ b/ci/Tekton/Tasks/rox-image-scan-task.yml
@@ -16,7 +16,7 @@ spec:
       description: Full name of image to scan (example -- gcr.io/rox/sample:5.0-rc1)
     - name: output_format
       type: string
-      description:  Output format (json | csv | pretty)
+      description:  Output format (json | csv | table)
       default: json
   steps:
     - name: rox-image-scan
@@ -36,6 +36,6 @@ spec:
         #!/usr/bin/env bash
         set +x
         export NO_COLOR="True"
-        curl -k -L -H "Authorization: Bearer $ROX_API_TOKEN" https://$ROX_CENTRAL_ENDPOINT/api/cli/download/roxctl-linux --output ./roxctl  > /dev/null; echo "Getting roxctl" 
+        curl -k -L -H "Authorization: Bearer $ROX_API_TOKEN" https://$ROX_CENTRAL_ENDPOINT/api/cli/download/roxctl-linux --output ./roxctl  > /dev/null; echo "Getting roxctl"
         chmod +x ./roxctl > /dev/null
-        ./roxctl image scan --insecure-skip-tls-verify -e $ROX_CENTRAL_ENDPOINT --image $(params.image) --format $(params.output_format) 
+        ./roxctl image scan --insecure-skip-tls-verify -e $ROX_CENTRAL_ENDPOINT --image $(params.image) --format $(params.output_format)

--- a/ci/Tekton/Tasks/rox-image-scan-task.yml
+++ b/ci/Tekton/Tasks/rox-image-scan-task.yml
@@ -38,4 +38,7 @@ spec:
         export NO_COLOR="True"
         curl -k -L -H "Authorization: Bearer $ROX_API_TOKEN" https://$ROX_CENTRAL_ENDPOINT/api/cli/download/roxctl-linux --output ./roxctl  > /dev/null; echo "Getting roxctl"
         chmod +x ./roxctl > /dev/null
+        
+        echo "Scanning image: $(params.image)"
+        
         ./roxctl image scan --insecure-skip-tls-verify -e $ROX_CENTRAL_ENDPOINT --image $(params.image) --format $(params.output_format)


### PR DESCRIPTION
Modify the rox-image-check tekon task to pass the pass the result of the scan as a tekton result that can be consumed in downstream tasks. Remove check_output result which was not being used and doesn't work anyway since tekton results can only hold very limited amount of data.