### PR TITLE
update to work with latest roxctl

### DIFF
--- a/ci/Tekton/Sample/rox-pipeline.yml
+++ b/ci/Tekton/Sample/rox-pipeline.yml
@@ -22,7 +22,7 @@ spec:
     - name: rox_central_endpoint
       value: roxsecrets
     - name: output_format
-      value: pretty
+      value: json
   - name: image-check
     taskRef:
       name: rox-image-check

--- a/ci/Tekton/Tasks/rox-image-scan-task.yml
+++ b/ci/Tekton/Tasks/rox-image-scan-task.yml
@@ -16,7 +16,7 @@ spec:
       description: Full name of image to scan (example -- gcr.io/rox/sample:5.0-rc1)
     - name: output_format
       type: string
-      description:  Output format (json | csv | pretty)
+      description:  Output format (json | csv )
       default: json
   steps:
     - name: rox-image-scan
@@ -38,4 +38,4 @@ spec:
         export NO_COLOR="True"
         curl -k -L -H "Authorization: Bearer $ROX_API_TOKEN" https://$ROX_CENTRAL_ENDPOINT/api/cli/download/roxctl-linux --output ./roxctl  > /dev/null; echo "Getting roxctl" 
         chmod +x ./roxctl > /dev/null
-        ./roxctl image scan --insecure-skip-tls-verify -e $ROX_CENTRAL_ENDPOINT --image $(params.image) --format $(params.output_format) 
+        ./roxctl image scan --insecure-skip-tls-verify -e $ROX_CENTRAL_ENDPOINT --image $(params.image) --output $(params.output_format) 


### PR DESCRIPTION
When executing this example the scan task reported that the --format option is no longer available. I updated it to --output which does not appear to take the "pretty" option, so I also changed it to output as json as part of the example.