### PR TITLE
changing policy name to examine to "fixable severity at least important"

### DIFF
--- a/util-scripts/export-cves-to-csv/create-csv.sh
+++ b/util-scripts/export-cves-to-csv/create-csv.sh
@@ -27,7 +27,7 @@ function curl_central() {
 # Collect all alerts
 cvss=7
 
-res="$(curl_central "v1/alerts?query=Policy%3AFixable%20CVSS%20%3E%3D%20${cvss}")"
+res="$(curl_central "v1/alerts?query=Policy%3AFixable%20Severity%20at%20least%20Important")"
 
 # Iterate over all deployments and get the full deployment
 for deployment_id in $(echo "${res}" | jq -r .alerts[].deployment.id); do


### PR DESCRIPTION
The original script uses violations of the policy "Fixable CVSS > 7", which has been disabled in ACS. This just changes the default policy name to the current "Fixable Severity at least Important"