### PR TITLE
cron based backups of ACS

### DIFF
--- a/backups/cron-backup.yaml
+++ b/backups/cron-backup.yaml
@@ -1,0 +1,56 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: backup-cron
+  namespace: stackrox
+spec:
+  concurrencyPolicy: Allow
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    metadata:
+      creationTimestamp: null
+    spec:
+      template:
+        metadata:
+          creationTimestamp: null
+        spec:
+          containers:
+            - args:
+                - -p
+                - $(ACS_ADMIN_PASSWORD)
+                - --output
+                - /mnt
+                - -e
+                - ###insert end point here or be professional and use a variable 
+                - --insecure-skip-tls-verify
+              command:
+                - roxctl
+                - central
+                - backup
+              env:  ###either retreieve the rox pass or create a token and store it in a secret the set the env, don't use passwords in Git!
+                - name: ACS_ADMIN_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      key: password
+                      name: acs-password
+              image: registry.redhat.io/advanced-cluster-security/rhacs-roxctl-rhel8:3.71.2
+              imagePullPolicy: IfNotPresent
+              name: backup-cron
+              resources: {}
+              terminationMessagePath: /dev/termination-log
+              terminationMessagePolicy: File
+              volumeMounts:
+                - mountPath: /mnt
+                  name: stackrox-backups-uat
+          dnsPolicy: ClusterFirst
+          restartPolicy: OnFailure
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+          volumes:
+            - name: stackrox-backups-uat
+              persistentVolumeClaim:
+                claimName: stackrox-backups-uat
+  schedule: 05 1 * * *
+  successfulJobsHistoryLimit: 3
+  suspend: false

--- a/backups/readme.md
+++ b/backups/readme.md
@@ -1,0 +1,10 @@
+This is a simple example of running ACS/Stackrox backups in a container and storing them on a persistent volume. 
+
+cron-backups.yaml creates a container from the roxctl image and runs a backup storing it in a PVC mounted on /mnt
+- You can utilize ROX_API_TOKEN as an env variable and store an API token in a secret
+- You can utilize ROX_CENTRAL_ADDRESS as an env variable as well
+- The above env variables were not used in this case with hopes of showing simple examples that could be built upon. 
+
+retreive-backups-pod.yaml creates a simple container that mounts a PVC where you could retrieve a backup, if needed. (obviously you need to mount the correct PVC)
+
+There are many ways to achieve the backup task. This was done for an environment where access was limited and the ACS team only had access to persistent storage via the cluster. 

--- a/backups/retrieve-backups-pod.yaml
+++ b/backups/retrieve-backups-pod.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: retrieve-backups
+  namespace: stackrox
+spec:
+  containers:
+    - name: retrieve-backups
+      image: 'registry.access.redhat.com/ubi8/ubi'
+      volumeMounts:
+        - mountPath: /mnt
+          name: stackrox-backups
+      command: [ "/bin/bash", "-c", "--" ]
+      args: [ "while true; do sleep 30; done;" ]
+  volumes:
+    - name: stackrox-backups-uat
+      persistentVolumeClaim:
+        claimName: stackrox-backups-uat


### PR DESCRIPTION
Developed for customer with limited cluster access and only access to storage via OCP PV/PVCs. Possibly of help to others. This was kept as simple as possible to a "new to K8s team". 