### PR TITLE
Add support for multiple clusters and include namespace

### DIFF
--- a/util-scripts/export-cves-to-csv/create-csv.sh
+++ b/util-scripts/export-cves-to-csv/create-csv.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+VERSION="${VERSION:-v1}"
+
 if [[ -z "${ROX_ENDPOINT}" ]]; then
   echo >&2 "ROX_ENDPOINT must be set"
   exit 1
@@ -18,8 +20,16 @@ if [[ -z "$1" ]]; then
 fi
 
 output_file="$1"
-#echo '"Deployment", "Image", "CVE", "CVSS Score", "Summary", "Severity", "Component", "Version", "Fixed By", "Layer Index", "Layer Instruction"' > "${output_file}"
-echo '"Cluster Name", "Cluster Id", "Namespace", "Namespace Id","Deployment", "Image", "CVE", "CVSS Score", "Summary", "Severity", "Component", "Version", "Fixed By", "Layer Index", "Layer Instruction"' > "${output_file}"
+if [[ "${VERSION}" == "v1" ]]; then
+  echo '"Deployment", "Image", "CVE", "CVSS Score", "Summary", "Severity", "Component", "Version", "Fixed By", "Layer Index", "Layer Instruction"' > "${output_file}"
+elif [[ "${VERSION}" == "v2" ]]; then
+  echo '"Cluster Name", "Cluster Id", "Namespace", "Namespace Id","Deployment", "Image", "CVE", "CVSS Score", "Summary", "Severity", "Component", "Version", "Fixed By", "Layer Index", "Layer Instruction"' > "${output_file}"
+else
+  echo "Unknown version ${VERSION} detected. v1 and v2 supported"
+  exit 1
+fi
+
+exit 0
 
 function curl_central() {
   curl -sk -H "Authorization: Bearer ${ROX_API_TOKEN}" "https://${ROX_ENDPOINT}/$1"
@@ -59,7 +69,11 @@ for deployment_id in $(echo "${res}" | jq -r .alerts[].deployment.id); do
        export image_name
        
        # Format the CSV correctly
-       echo "${image_res}" | jq -r --argjson cvss "$cvss" 'try (.metadata.v1.layers as $layers | .scan.components | sort_by(.layerIndex, .name) | .[]? | . as $component | select(.vulns != null) | .vulns[] | select(.cvss >= $cvss) | select(.fixedBy != null) | [ env.clusterName, env.clusterId, env.namespace, env.namespaceId, env.deployment_name, env.image_name, .cve, .cvss, .summary, .severity, $component.name, $component.version, .fixedBy, $component.layerIndex, ($layers[$component.layerIndex // 0].instruction + " " +$layers[$component.layerIndex // 0].value)]) | @csv' >> "${output_file}"
+       if [[ "${VERSION}" == "v1" ]]; then
+         echo "${image_res}" | jq -r --argjson cvss "$cvss" 'try (.metadata.v1.layers as $layers | .scan.components | sort_by(.layerIndex, .name) | .[]? | . as $component | select(.vulns != null) | .vulns[] | select(.cvss >= $cvss) | select(.fixedBy != null) | [ env.deployment_name, env.image_name, .cve, .cvss, .summary, .severity, $component.name, $component.version, .fixedBy, $component.layerIndex, ($layers[$component.layerIndex // 0].instruction + " " +$layers[$component.layerIndex // 0].value)]) | @csv' >> "${output_file}"
+       else
+         echo "${image_res}" | jq -r --argjson cvss "$cvss" 'try (.metadata.v1.layers as $layers | .scan.components | sort_by(.layerIndex, .name) | .[]? | . as $component | select(.vulns != null) | .vulns[] | select(.cvss >= $cvss) | select(.fixedBy != null) | [ env.clusterName, env.clusterId, env.namespace, env.namespaceId, env.deployment_name, env.image_name, .cve, .cvss, .summary, .severity, $component.name, $component.version, .fixedBy, $component.layerIndex, ($layers[$component.layerIndex // 0].instruction + " " +$layers[$component.layerIndex // 0].value)]) | @csv' >> "${output_file}"
+       fi
      fi
    done
   done

--- a/util-scripts/export-cves-to-csv/create-csv.sh
+++ b/util-scripts/export-cves-to-csv/create-csv.sh
@@ -18,7 +18,8 @@ if [[ -z "$1" ]]; then
 fi
 
 output_file="$1"
-echo '"Deployment", "Image", "CVE", "CVSS Score", "Summary", "Severity", "Component", "Version", "Fixed By", "Layer Index", "Layer Instruction"' > "${output_file}"
+#echo '"Deployment", "Image", "CVE", "CVSS Score", "Summary", "Severity", "Component", "Version", "Fixed By", "Layer Index", "Layer Instruction"' > "${output_file}"
+echo '"Cluster Name", "Cluster Id", "Namespace", "Namespace Id","Deployment", "Image", "CVE", "CVSS Score", "Summary", "Severity", "Component", "Version", "Fixed By", "Layer Index", "Layer Instruction"' > "${output_file}"
 
 function curl_central() {
   curl -sk -H "Authorization: Bearer ${ROX_API_TOKEN}" "https://${ROX_ENDPOINT}/$1"
@@ -40,9 +41,12 @@ for deployment_id in $(echo "${res}" | jq -r .alerts[].deployment.id); do
    continue;
   fi
 
-  deployment_name="$(echo "${deployment_res}" | jq -rc .name)"
-  export deployment_name
-    
+  export deployment_name="$(echo "${deployment_res}" | jq -rc .name)"
+  export namespace="$(echo "${deployment_res}" | jq -rc .namespace)"
+  export namespaceId="$(echo "${deployment_res}" | jq -rc .namespaceId)"
+  export clusterName="$(echo "${deployment_res}" | jq -rc .clusterName)"
+  export clusterId="$(echo "${deployment_res}" | jq -rc .clusterId)"
+
    # Iterate over all images within the deployment and render the CSV Lines
    for image_id in $(echo "${deployment_res}" | jq -r 'select(.containers != null) | .containers[].image.id'); do
      if [[ "${image_id}" != "" ]]; then
@@ -55,7 +59,7 @@ for deployment_id in $(echo "${res}" | jq -r .alerts[].deployment.id); do
        export image_name
        
        # Format the CSV correctly
-       echo "${image_res}" | jq -r --argjson cvss "$cvss" 'try (.metadata.v1.layers as $layers | .scan.components | sort_by(.layerIndex, .name) | .[]? | . as $component | select(.vulns != null) | .vulns[] | select(.cvss >= $cvss) | select(.fixedBy != null) | [ env.deployment_name, env.image_name, .cve, .cvss, .summary, .severity, $component.name, $component.version, .fixedBy, $component.layerIndex, ($layers[$component.layerIndex // 0].instruction + " " +$layers[$component.layerIndex // 0].value)]) | @csv' >> "${output_file}"
+       echo "${image_res}" | jq -r --argjson cvss "$cvss" 'try (.metadata.v1.layers as $layers | .scan.components | sort_by(.layerIndex, .name) | .[]? | . as $component | select(.vulns != null) | .vulns[] | select(.cvss >= $cvss) | select(.fixedBy != null) | [ env.clusterName, env.clusterId, env.namespace, env.namespaceId, env.deployment_name, env.image_name, .cve, .cvss, .summary, .severity, $component.name, $component.version, .fixedBy, $component.layerIndex, ($layers[$component.layerIndex // 0].instruction + " " +$layers[$component.layerIndex // 0].value)]) | @csv' >> "${output_file}"
      fi
    done
   done


### PR DESCRIPTION
The current script does not include the cluster name or ID and does not include the namespace name and ID. Many of my customers use this tool to export reports from ACS. They run multiple clusters with multiple tenants and would like to be able to easily distinguish which parts are coming from which.

I updated the script to retain the current output unless the user overrides this behavior with a VERSION flag. By defaulting to the original "v1", any tooling built on the output of this script will continue to work using the original format. Customers that want to use the second version can simply set VERSION="v2" when running the tool