### PR TITLE
roxctl-grace-period

### DIFF
--- a/util-scripts/roxctl-grace-period/README.md
+++ b/util-scripts/roxctl-grace-period/README.md
@@ -1,0 +1,10 @@
+Parses results from "roxctl image scan" to determine which fixable CVEs fall into a defined "Grace Period" in days. Default grace period is 30 days.
+
+Output lists each Fixable CVE as
+- "in grace": CVE Published less than "grace period" days ago 
+- "in grace": CVE Published more than "grace period" days ago 
+
+Usage:
+
+`roxctl image scan -e $CENTRAL:443 --image quay.io/example:1.0 | ./grace.py
+`

--- a/util-scripts/roxctl-grace-period/README.md
+++ b/util-scripts/roxctl-grace-period/README.md
@@ -2,7 +2,7 @@ Parses results from "roxctl image scan" to determine which fixable CVEs fall int
 
 Output lists each Fixable CVE as
 - "in grace": CVE Published less than "grace period" days ago 
-- "in grace": CVE Published more than "grace period" days ago 
+- "out of grace": CVE Published more than "grace period" days ago 
 
 Usage:
 

--- a/util-scripts/roxctl-grace-period/grace.py
+++ b/util-scripts/roxctl-grace-period/grace.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+
+import sys
+import json
+from datetime import datetime, timedelta
+
+gracePeriod=30
+currentTime=datetime.now()
+
+image_json = json.load(sys.stdin)
+
+#print(image_json["scan"]["components"][0])
+
+for component in image_json["scan"]["components"]:
+    try:
+        for vuln in component["vulns"]:
+            try:
+                if vuln["fixedBy"]:
+                    pubTimestamp = datetime.strptime(vuln["publishedOn"][0:10], "%Y-%m-%d")
+                    if (currentTime - timedelta(days=gracePeriod)) > pubTimestamp:
+                        print ("out of grace: ", component["name"], vuln["cve"], vuln["severity"], vuln["fixedBy"], vuln["publishedOn"])
+                    else:
+                        print ("in grace: ", component["name"], vuln["cve"], vuln["severity"], vuln["fixedBy"], vuln["publishedOn"])
+                    #print (vuln["cve"])
+            except KeyError:
+                pass
+    except KeyError:
+        pass


### PR DESCRIPTION
Example python script to parse the output of "roxctl image scan" to break down fixable images into two categories: those CVEs that were published less than X days ago ("in grace") and those published more than X days ago ("out of grace").

Intended as an example for build-time implementation of an automatic grace period for newly discovered CVEs.