### PR TITLE
Jv filter control plane components in listening_endpoints

### DIFF
--- a/util-scripts/listening-endpoints/listening-endpoints.sh
+++ b/util-scripts/listening-endpoints/listening-endpoints.sh
@@ -101,7 +101,6 @@ get_deployments() {
         fi
     
         ndeployment="$(echo $json_deployments | jq '.deployments | length')"
-        deployments=()
         for ((i = 0; i < ndeployment; i = i + 1)); do
             deployments+=("$(echo "$json_deployments" | jq .deployments[$i].id | tr -d '"')")
         done
@@ -204,6 +203,7 @@ get_listening_endpoints_for_table() {
 
 process_args $@
 
+deployments=()
 get_deployments
 declare -A pod_node_map  # associative array to store pod ID as key and node as value
 create_pod_node_map

--- a/util-scripts/listening-endpoints/listening-endpoints.sh
+++ b/util-scripts/listening-endpoints/listening-endpoints.sh
@@ -85,7 +85,6 @@ get_deployments() {
         fi
 
         if [[ "$control_plane_value" == "without_control_plane" ]]; then
-    	    #json_deployments="$(echo "$json_deployments" | jq '{deployments: [.deployments[] | select(.namespace != kube-node-lease && .namespace != kube-public && .namespace != kube-system)]}')"
 	    json_deployments="$(echo "$json_deployments" | jq '{deployments: [.deployments[] | select(.namespace != "kube-node-lease" and .namespace != "kube-public" and .namespace != "kube-system")]}')"
         fi
     


### PR DESCRIPTION
Adds the ability to filter out listening endpoints created by control plane components from the listening endpoints service. Also adds the ability to do the reverse and only show listening endpoints created by control plane components.