### PR TITLE
Add PolKit local privilege escalation policies

### DIFF
--- a/policies/CVE-2021-4034-build-deploy.json
+++ b/policies/CVE-2021-4034-build-deploy.json
@@ -1,0 +1,52 @@
+{
+    "policies": [
+        {
+            "name": "PwnKit: CVE-2021-4034 - PolKit local privilege escalation vulnerability",
+            "description": "Alert on deployments with images containing the PwnKit vulnerability (CVE-2021-4034). This is a local privilege escalation vulnerability impacting the pkexec binary.",
+            "rationale": "This vulnerability allows an unprivileged local attacker to escalate privileges, bypassing any authentication and policies due to incorrect handling of the process argument vector.",
+            "remediation": "Update the polkit package to 0.112-26.el7_9.1 (for RHEL 7-based container images) or polkit-0.115-13.el8_5.1 (for RHEL 8-based container images).",
+            "disabled": false,
+            "categories": [
+                "Vulnerability Management"
+            ],
+            "fields": null,
+            "lifecycleStages": [
+                "BUILD",
+                "DEPLOY"
+            ],
+            "eventSource": "NOT_APPLICABLE",
+            "whitelists": [],
+            "exclusions": [],
+            "scope": [],
+            "severity": "CRITICAL_SEVERITY",
+            "enforcementActions": [],
+            "notifiers": [],
+            "lastUpdated": null,
+            "SORTName": "",
+            "SORTLifecycleStage": "",
+            "SORTEnforcement": false,
+            "policyVersion": "1.1",
+            "policySections": [
+                {
+                    "sectionName": "",
+                    "policyGroups": [
+                        {
+                            "fieldName": "CVE",
+                            "booleanOperator": "OR",
+                            "negate": false,
+                            "values": [
+                                {
+                                    "value": "CVE-2021-4034"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "mitreAttackVectors": [],
+            "criteriaLocked": true,
+            "mitreVectorsLocked": true,
+            "isDefault": false
+        }
+    ]
+}

--- a/policies/CVE-2021-4034-build-deploy.json
+++ b/policies/CVE-2021-4034-build-deploy.json
@@ -1,7 +1,7 @@
 {
     "policies": [
         {
-            "name": "PwnKit: CVE-2021-4034 - PolKit local privilege escalation vulnerability",
+            "name": "PwnKit: CVE-2021-4034 - Polkit local privilege escalation vulnerability",
             "description": "Alert on deployments with images containing the PwnKit vulnerability (CVE-2021-4034). This is a local privilege escalation vulnerability impacting the pkexec binary.",
             "rationale": "This vulnerability allows an unprivileged local attacker to escalate privileges, bypassing any authentication and policies due to incorrect handling of the process argument vector.",
             "remediation": "Update the polkit package to 0.112-26.el7_9.1 (for RHEL 7-based container images) or polkit-0.115-13.el8_5.1 (for RHEL 8-based container images).",

--- a/policies/polkit-execution.json
+++ b/policies/polkit-execution.json
@@ -1,10 +1,10 @@
 {
     "policies": [
         {
-            "name": "PolKit Execution Detected",
-            "description": "Detects execution of the PolKit binary in a container",
-            "rationale": "PolKit can be abused by attackers to elevate privileges within a container.",
-            "remediation": "Use your package manager's \"remove\" command to remove polkit from the image build for production containers.",
+            "name": "Polkit Execution Detected",
+            "description": "Detects execution of the pkexec binary in a container",
+            "rationale": "Polkit can be abused by attackers to elevate privileges within a container.",
+            "remediation": "Use your package manager's \"remove\" command to remove polkit packages from the image build for production containers.",
             "disabled": false,
             "categories": [
                 "Security Best Practices"
@@ -18,7 +18,7 @@
             "severity": "MEDIUM_SEVERITY",
             "enforcementActions": [],
             "notifiers": [],
-            "SORTName": "PolKit Execution Detected",
+            "SORTName": "Polkit Execution Detected",
             "SORTLifecycleStage": "RUNTIME",
             "SORTEnforcement": false,
             "policyVersion": "1.1",

--- a/policies/polkit-execution.json
+++ b/policies/polkit-execution.json
@@ -1,0 +1,44 @@
+{
+    "name": "PolKit Execution Detected",
+    "description": "Detects execution of the PolKit binary in a container",
+    "rationale": "PolKit can be abused by attackers to elevate privileges within a container.",
+    "remediation": "Use your package manager's \"remove\" command to remove polkit from the image build for production containers.",
+    "disabled": false,
+    "categories": [
+        "Security Best Practices"
+    ],
+    "lifecycleStages": [
+        "RUNTIME"
+    ],
+    "eventSource": "DEPLOYMENT_EVENT",
+    "exclusions": [],
+    "scope": [],
+    "severity": "MEDIUM_SEVERITY",
+    "enforcementActions": [],
+    "notifiers": [],
+    "SORTName": "PolKit Execution Detected",
+    "SORTLifecycleStage": "RUNTIME",
+    "SORTEnforcement": false,
+    "policyVersion": "1.1",
+    "policySections": [
+        {
+            "sectionName": "",
+            "policyGroups": [
+                {
+                    "fieldName": "Process Name",
+                    "booleanOperator": "OR",
+                    "negate": false,
+                    "values": [
+                        {
+                            "value": "pkexec"
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "mitreAttackVectors": [],
+    "criteriaLocked": true,
+    "mitreVectorsLocked": true,
+    "isDefault": false
+}

--- a/policies/polkit-execution.json
+++ b/policies/polkit-execution.json
@@ -1,44 +1,48 @@
 {
-    "name": "PolKit Execution Detected",
-    "description": "Detects execution of the PolKit binary in a container",
-    "rationale": "PolKit can be abused by attackers to elevate privileges within a container.",
-    "remediation": "Use your package manager's \"remove\" command to remove polkit from the image build for production containers.",
-    "disabled": false,
-    "categories": [
-        "Security Best Practices"
-    ],
-    "lifecycleStages": [
-        "RUNTIME"
-    ],
-    "eventSource": "DEPLOYMENT_EVENT",
-    "exclusions": [],
-    "scope": [],
-    "severity": "MEDIUM_SEVERITY",
-    "enforcementActions": [],
-    "notifiers": [],
-    "SORTName": "PolKit Execution Detected",
-    "SORTLifecycleStage": "RUNTIME",
-    "SORTEnforcement": false,
-    "policyVersion": "1.1",
-    "policySections": [
+    "policies": [
         {
-            "sectionName": "",
-            "policyGroups": [
+            "name": "PolKit Execution Detected",
+            "description": "Detects execution of the PolKit binary in a container",
+            "rationale": "PolKit can be abused by attackers to elevate privileges within a container.",
+            "remediation": "Use your package manager's \"remove\" command to remove polkit from the image build for production containers.",
+            "disabled": false,
+            "categories": [
+                "Security Best Practices"
+            ],
+            "lifecycleStages": [
+                "RUNTIME"
+            ],
+            "eventSource": "DEPLOYMENT_EVENT",
+            "exclusions": [],
+            "scope": [],
+            "severity": "MEDIUM_SEVERITY",
+            "enforcementActions": [],
+            "notifiers": [],
+            "SORTName": "PolKit Execution Detected",
+            "SORTLifecycleStage": "RUNTIME",
+            "SORTEnforcement": false,
+            "policyVersion": "1.1",
+            "policySections": [
                 {
-                    "fieldName": "Process Name",
-                    "booleanOperator": "OR",
-                    "negate": false,
-                    "values": [
+                    "sectionName": "",
+                    "policyGroups": [
                         {
-                            "value": "pkexec"
+                            "fieldName": "Process Name",
+                            "booleanOperator": "OR",
+                            "negate": false,
+                            "values": [
+                                {
+                                    "value": "pkexec"
+                                }
+                            ]
                         }
                     ]
                 }
-            ]
+            ],
+            "mitreAttackVectors": [],
+            "criteriaLocked": true,
+            "mitreVectorsLocked": true,
+            "isDefault": false
         }
-    ],
-    "mitreAttackVectors": [],
-    "criteriaLocked": true,
-    "mitreVectorsLocked": true,
-    "isDefault": false
+    ]
 }

--- a/policies/polkit-in-image.json
+++ b/policies/polkit-in-image.json
@@ -1,10 +1,10 @@
 {
     "policies": [
         {
-            "name": "PolKit in Image",
-            "description": "Alert on deployments with PolKit present",
-            "rationale": "Leaving privilege escalation tools like PolKit in an image potentially allows attackers to escalate privileges within the container.",
-            "remediation": "Use your package manager's \"remove\" command to remove PolKit from the image build for production containers.",
+            "name": "Polkit in Image",
+            "description": "Alert on deployments with Polkit present",
+            "rationale": "Leaving privileged administration tools like Polkit in an image potentially allows attackers to escalate privileges within the container.",
+            "remediation": "Use your package manager's \"remove\" command to remove polkit packages from the image build for production containers.",
             "disabled": false,
             "categories": [
                 "Security Best Practices"

--- a/policies/polkit-in-image.json
+++ b/policies/polkit-in-image.json
@@ -1,0 +1,54 @@
+{
+    "policies": [
+        {
+            "name": "PolKit in Image",
+            "description": "Alert on deployments with PolKit present",
+            "rationale": "Leaving privilege escalation tools like PolKit in an image potentially allows attackers to escalate privileges within the container.",
+            "remediation": "Use your package manager's \"remove\" command to remove PolKit from the image build for production containers.",
+            "disabled": false,
+            "categories": [
+                "Security Best Practices"
+            ],
+            "fields": null,
+            "lifecycleStages": [
+                "BUILD",
+                "DEPLOY"
+            ],
+            "eventSource": "NOT_APPLICABLE",
+            "whitelists": [],
+            "exclusions": [],
+            "scope": [],
+            "severity": "LOW_SEVERITY",
+            "enforcementActions": [],
+            "notifiers": [],
+            "SORTName": "",
+            "SORTLifecycleStage": "",
+            "SORTEnforcement": false,
+            "policyVersion": "1.1",
+            "policySections": [
+                {
+                    "sectionName": "",
+                    "policyGroups": [
+                        {
+                            "fieldName": "Image Component",
+                            "booleanOperator": "OR",
+                            "negate": false,
+                            "values": [
+                                {
+                                    "value": "polkit="
+                                },
+                                {
+                                    "value": "policykit-1="
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "mitreAttackVectors": [],
+            "criteriaLocked": false,
+            "mitreVectorsLocked": false,
+            "isDefault": false
+        }
+    ]
+}


### PR DESCRIPTION
Adds policies that can be used to mitigate a PolKit local privilege escalation vulnerability:
* Scan images and detect `polkit` and `policykit-1` packages vulnerable to CVE-2021-4034
* Identify `polkit` or `policykit-1` packages present in container images
* Detect `pkexec` usage at runtime. 

These policies can be validated by inspecting the `quay.io/the-worst-containers/pwnkit:v0.2` image:
```
 roxctl -e "stackrox" --insecure-skip-tls-verify image check --image  quay.io/the-worst-containers/pwnkit:v0.2
Policy check results for image: quay.io/the-worst-containers/pwnkit:v0.2
(TOTAL: 5, LOW: 3, MEDIUM: 0, HIGH: 1, CRITICAL: 1)

+--------------------------------+----------+--------------+--------------------------------+--------------------------------+--------------------------------+
|             POLICY             | SEVERITY | BREAKS BUILD |          DESCRIPTION           |           VIOLATION            |          REMEDIATION           |
+--------------------------------+----------+--------------+--------------------------------+--------------------------------+--------------------------------+
| PwnKit: CVE-2021-4034 - PolKit | CRITICAL |      -       |   Alert on deployments with    |   - CVE-2021-4034 (CVSS 7.8)   |  Update the polkit package to  |
|   local privilege escalation   |          |              |  images containing the PwnKit  |   (severity Important) found   |   0.112-26.el7_9.1 (for RHEL   |
|         vulnerability          |          |              | vulnerability (CVE-2021-4034). |   in component 'policykit-1'   |   7-based container images)    |
|                                |          |              |   This is a local privilege    |   (version 0.105-18+deb9u1)    |   or polkit-0.115-13.el8_5.1   |
|                                |          |              |    escalation vulnerability    |                                |  (for RHEL 8-based container   |
|                                |          |              |  impacting the pkexec binary.  |                                |            images).            |
+--------------------------------+----------+--------------+--------------------------------+--------------------------------+--------------------------------+
|   Fixable Severity at least    |   HIGH   |      X       |   Alert on deployments with    | - Fixable CVE-2020-1712 (CVSS  |  Use your package manager to   |
|           Important            |          |              |  fixable vulnerabilities with  |   7.8) (severity Important)    |  update to a fixed version in  |
|                                |          |              |   a Severity Rating at least   |  found in component 'systemd'  |  future builds or speak with   |
|                                |          |              |           Important            |   (version 232-25+deb9u13),    | your security team to mitigate |
|                                |          |              |                                |      resolved by version       |      the vulnerabilities.      |
|                                |          |              |                                |         232-25+deb9u14         |                                |
|                                |          |              |                                |                                |                                |
|                                |          |              |                                |    - Fixable CVE-2021-4034     |                                |
|                                |          |              |                                |      (CVSS 7.8) (severity      |                                |
|                                |          |              |                                | Important) found in component  |                                |
|                                |          |              |                                |     'policykit-1' (version     |                                |
|                                |          |              |                                | 0.105-18+deb9u1), resolved by  |                                |
|                                |          |              |                                |    version 0.105-18+deb9u2     |                                |
+--------------------------------+----------+--------------+--------------------------------+--------------------------------+--------------------------------+
|  Docker CIS 4.1: Ensure That   |   LOW    |      -       |   Containers should run as a   |    - Image has user 'root'     | Ensure that the Dockerfile for |
|  a User for the Container Has  |          |              |         non-root user          |                                |  each container switches from  |
|          Been Created          |          |              |                                |                                |         the root user          |
+--------------------------------+----------+--------------+--------------------------------+--------------------------------+--------------------------------+
|        PolKit in Image         |   LOW    |      -       |   Alert on deployments with    |   - Image includes component   |   Use your package manager's   |
|                                |          |              |         PolKit present         |     'policykit-1' (version     |   "remove" command to remove   |
|                                |          |              |                                |        0.105-18+deb9u1)        |  PolKit from the image build   |
|                                |          |              |                                |                                |   for production containers.   |
+--------------------------------+----------+--------------+--------------------------------+--------------------------------+--------------------------------+
|   Ubuntu Package Manager in    |   LOW    |      -       |      Alert on deployments      |   - Image includes component   |    Run `dpkg -r --force-all    |
|             Image              |          |              |     with components of the     |     'apt' (version 1.4.11)     |     apt apt-get && dpkg -r     |
|                                |          |              |     Debian/Ubuntu package      |                                |  --force-all debconf dpkg` in  |
|                                |          |              |    management system in the    |   - Image includes component   | the image build for production |
|                                |          |              |             image.             |    'dpkg' (version 1.18.26)    |          containers.           |
+--------------------------------+----------+--------------+--------------------------------+--------------------------------+--------------------------------+
```