### PR TITLE
Jv change column name to process name

### DIFF
--- a/util-scripts/listening-endpoints/listening-endpoints.sh
+++ b/util-scripts/listening-endpoints/listening-endpoints.sh
@@ -188,7 +188,7 @@ get_listening_endpoints_for_table() {
     
     echo
     header=$(printf "%-20s %-9s %-7s %-7s %-15s %-40s %-55s %-20s" \
-        "Program name" "PID" "Port" "Proto" "Namespace" "clusterId" \
+        "Process name" "PID" "Port" "Proto" "Namespace" "clusterId" \
         "podId" "containerName")
 
 


### PR DESCRIPTION
Process name is more accurate and more consistent with other APIs and the UI.