### PR TITLE
Jv change process name to exec file path

### DIFF
--- a/util-scripts/listening-endpoints/listening-endpoints.sh
+++ b/util-scripts/listening-endpoints/listening-endpoints.sh
@@ -164,6 +164,7 @@ get_listening_endpoints_for_table() {
     
                 listening_endpoint="$(echo $listening_endpoints | jq -r .listeningEndpoints[$j])"
                 name="$(echo $listening_endpoint | jq -r .signal.name)"
+                exec_file_path="$(echo $listening_endpoint | jq -r .signal.execFilePath)"
                 plop_port="$(echo $listening_endpoint | jq -r .endpoint.port)"
                 namespace="$(echo $listening_endpoint | jq -r .namespace)"
                 clusterId="$(echo $listening_endpoint | jq -r .clusterId)"
@@ -171,8 +172,8 @@ get_listening_endpoints_for_table() {
                 containerName="$(echo $listening_endpoint | jq -r .containerName)"
                 pid="$(echo $listening_endpoint | jq -r .signal.pid)"
 
-                table_line=$(printf "%-20s %-9s %-7s %-7s %-15s %-40s %-55s %-20s" \
-                    "$name" "$pid" "$plop_port" "$proto" "$namespace" "$clusterId" \
+                table_line=$(printf "%-40s %-9s %-7s %-7s %-15s %-40s %-55s %-20s" \
+                    "$exec_file_path" "$pid" "$plop_port" "$proto" "$namespace" "$clusterId" \
                     "$podId" "$containerName")
 
 		if [[ "$display_node_value" == "true" ]]; then
@@ -187,8 +188,8 @@ get_listening_endpoints_for_table() {
     done
     
     echo
-    header=$(printf "%-20s %-9s %-7s %-7s %-15s %-40s %-55s %-20s" \
-        "Process name" "PID" "Port" "Proto" "Namespace" "clusterId" \
+    header=$(printf "%-40s %-9s %-7s %-7s %-15s %-40s %-55s %-20s" \
+        "Exec file path" "PID" "Port" "Proto" "Namespace" "clusterId" \
         "podId" "containerName")
 
 


### PR DESCRIPTION
Changed the "Process name" column to "Exec file path" in the listening endpoints script.

Example

```
Exec file path                           PID       Port    Proto   Namespace       clusterId                                podId                                                   containerName       
/usr/pgsql-13/bin/postgres               17723     5432    tcp     stackrox        71b39c1a-72e8-4b72-8a0c-da2df32bfa77     central-db-784dbb68dc-nf2g2                             central-db          
/scanner                                 17322     8080    tcp     stackrox        71b39c1a-72e8-4b72-8a0c-da2df32bfa77     scanner-57d99448cd-p8xwg                                scanner             
/scanner                                 14661     9090    tcp     stackrox        71b39c1a-72e8-4b72-8a0c-da2df32bfa77     scanner-57d99448cd-2jbg9                                scanner             
/scanner                                 17322     8443    tcp     stackrox        71b39c1a-72e8-4b72-8a0c-da2df32bfa77     scanner-57d99448cd-p8xwg                                scanner             
/scanner                                 14661     8080    tcp     stackrox        71b39c1a-72e8-4b72-8a0c-da2df32bfa77     scanner-57d99448cd-2jbg9                                scanner             
/scanner                                 17322     9090    tcp     stackrox        71b39c1a-72e8-4b72-8a0c-da2df32bfa77     scanner-57d99448cd-p8xwg                                scanner             
/scanner                                 14661     8443    tcp     stackrox        71b39c1a-72e8-4b72-8a0c-da2df32bfa77     scanner-57d99448cd-2jbg9                                scanner             
/kube-dns                                7549      8081    tcp     kube-system     71b39c1a-72e8-4b72-8a0c-da2df32bfa77     kube-dns-fc686db9b-kv975                                kubedns             
/usr/sbin/dnsmasq                        8348      53      tcp     kube-system     71b39c1a-72e8-4b72-8a0c-da2df32bfa77     kube-dns-fc686db9b-kv975                                dnsmasq             
/kube-dns                                7386      10055   tcp     kube-system     71b39c1a-72e8-4b72-8a0c-da2df32bfa77     kube-dns-fc686db9b-55nr4                                kubedns             
/sidecar                                 7659      10054   tcp     kube-system     71b39c1a-72e8-4b72-8a0c-da2df32bfa77     kube-dns-fc686db9b-55nr4                                sidecar       
```