### PR TITLE
Update violations-to-csv to account for non-deployment based alerts

### DIFF
--- a/util-scripts/violations-to-csv/violations-to-csv.sh
+++ b/util-scripts/violations-to-csv/violations-to-csv.sh
@@ -18,7 +18,7 @@ if [[ -z "$1" ]]; then
 fi
 
 output_file="$1"
-echo '"Policy", "Description", "Severity", "Cluster", "Namespace", "Deployment", "Time", "Enforcement Count", "Enforcement Action"' > "${output_file}"
+echo '"Policy", "Description", "Severity", "Cluster", "Namespace", "Resource Type", "Resource Name", "Time", "Enforcement Count", "Enforcement Action"' > "${output_file}"
 
 function curl_central() {
   curl -sk -H "Authorization: Bearer ${ROX_API_TOKEN}" "https://${ROX_ENDPOINT}/$1"
@@ -41,5 +41,5 @@ echo $res | jq -c -r '.alerts[]' | while IFS= read alert; do
   echo "====="
   echo $alert
   echo "====="
-  echo "${alert}" | jq -r '[.policy.name, .policy.description, .policy.severity, .deployment.clusterName, .deployment.namespace, .deployment.name, .time, .enforcementCount, .enforcementAction] | @csv' >> "${output_file}"
+  echo "${alert}" | jq -r '[.policy.name, .policy.description, .policy.severity, .commonEntityInfo.clusterName, .commonEntityInfo.namespace, .commonEntityInfo.resourceType, (if (.commonEntityInfo.resourceType == "DEPLOYMENT") then .deployment.name else .resource.name end), .time, .enforcementCount, .enforcementAction] | @csv' >> "${output_file}"
 done


### PR DESCRIPTION
Script currently pulls cluster and namespace from `deployment` object which is deprecated - it should use `commonEntityInfo`. Furthermore for non-deployment alerts (such as when you create an audit log based policy), deployment name doesn't make sense.

This change adds a "Resource Type" column as well to make it clear which resource the alert is for.