### PR TITLE
Add simple script to export all policies as CSV

### DIFF
--- a/util-scripts/export-all-policies/README.md
+++ b/util-scripts/export-all-policies/README.md
@@ -1,0 +1,13 @@
+# Export all policies
+
+This script uses the StackRox API to export all policies (both user defined and system) to a JSON file.
+
+**Required Environment Vars:**
+* `ROX_ENDPOINT` - Host for StackRox central (central.example.com)
+* `ROX_API_TOKEN` - Token data from [StackRox API token](https://docs.openshift.com/acs/4.2/cli/using-the-roxctl-cli.html#authenticating-by-using-the-roxctl-cli_using-roxctl-cli)
+
+**Required Tools:**
+* `jq` is used by this script and must be installed.  Installation instructions for various platforms can be found [here](https://stedolan.github.io/jq/download/)
+
+**Usage**
+`./export-all-policies.sh <output filename>`

--- a/util-scripts/export-all-policies/export-all-policies.sh
+++ b/util-scripts/export-all-policies/export-all-policies.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# Purpose: Export all policies to JSON
+# Requires:
+# - curl, jq
+# - $ROX_API_TOKEN = contains an API token with the following permissions:
+#     Policy (read) - for example a token with the StackRox 'Analyst' role
+# - $ROX_ENDPOINT = hostname/address of StackRox Central (:port if not 443)
+# Actions:
+# - Exports all policies from ACS to JSON.
+
+if [[ -z "${ROX_ENDPOINT}" ]]; then
+  echo >&2 "Environment variable ROX_ENDPOINT must be set"
+  echo >&2 "export ROX_ENDPOINT=stackrox.example.com"
+  exit 1
+fi
+
+if [[ -z "${ROX_API_TOKEN}" ]]; then
+  echo >&2 "Environment variable ROX_API_TOKEN must be set"
+  echo >&2 "export ROX_API_TOKEN=$(cat token-file)"
+  exit 1
+fi
+
+if ! [[ -x "$(command -v curl)" ]]; then
+  echo >&2 "curl does not exist or is not in the PATH"
+  exit 1
+fi
+
+if ! [[ -x "$(command -v jq)" ]]; then
+  echo >&2 "jq does not exist or is not in the PATH"
+  exit 1
+fi
+
+if [[ -z "$1" ]]; then
+  echo >&2 "usage: export-all-policies.sh <output filename> "
+  exit 1
+fi
+output_file="$1"
+
+
+policies=$(curl -sk -H "Authorization: Bearer ${ROX_API_TOKEN}" "https://${ROX_ENDPOINT}/v1/policies" | jq -r '[.policies[].id] | @csv')
+curl -sk -X POST -H "Authorization: Bearer ${ROX_API_TOKEN}" "https://${ROX_ENDPOINT}/v1/policies/export" --data-raw "{\"policyIds\":[${policies}]}" | jq -r . > "${output_file}"


### PR DESCRIPTION
Keeping it pretty simple. Future optimization could include supporting limiting which policies get exported (by id, name, category or query)