### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/add-new-pr-to-oss-triaging.yml
+++ b/.github/workflows/add-new-pr-to-oss-triaging.yml
@@ -24,12 +24,12 @@ jobs:
         run: |
           set -uo pipefail
           if [[ $BASE_REPO != $HEAD_REPO ]]; then
-            echo "is_external_pr=true" >> $GITHUB_ENV
+            echo "is_external_pr=true" >> $GITHUB_OUTPUT
             gh pr edit \
               ${{ github.event.pull_request.number }} \
               --add-label ${EXTERNAL_PR_LABEL}
           else
-            echo "is_external_pr=false" >> $GITHUB_ENV
+            echo "is_external_pr=false" >> $GITHUB_OUTPUT
           fi
 
   add-to-project:

--- a/.github/workflows/add-new-pr-to-oss-triaging.yml
+++ b/.github/workflows/add-new-pr-to-oss-triaging.yml
@@ -24,12 +24,12 @@ jobs:
         run: |
           set -uo pipefail
           if [[ $BASE_REPO != $HEAD_REPO ]]; then
-            echo "is_external_pr=true" >> $GITHUB_OUTPUT
+            echo "is_external_pr=true" >> "$GITHUB_OUTPUT"
             gh pr edit \
               ${{ github.event.pull_request.number }} \
               --add-label ${EXTERNAL_PR_LABEL}
           else
-            echo "is_external_pr=false" >> $GITHUB_OUTPUT
+            echo "is_external_pr=false" >> "$GITHUB_OUTPUT"
           fi
 
   add-to-project:

--- a/.github/workflows/add-new-pr-to-oss-triaging.yml
+++ b/.github/workflows/add-new-pr-to-oss-triaging.yml
@@ -24,12 +24,12 @@ jobs:
         run: |
           set -uo pipefail
           if [[ $BASE_REPO != $HEAD_REPO ]]; then
-            echo "::set-output name=is_external_pr::true"
+            echo "is_external_pr=true" >> $GITHUB_ENV
             gh pr edit \
               ${{ github.event.pull_request.number }} \
               --add-label ${EXTERNAL_PR_LABEL}
           else
-            echo "::set-output name=is_external_pr::false"
+            echo "is_external_pr=false" >> $GITHUB_ENV
           fi
 
   add-to-project:


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter


