### PR TITLE
Jv get deployments faster

### DIFF
--- a/util-scripts/listening-endpoints/listening-endpoints.sh
+++ b/util-scripts/listening-endpoints/listening-endpoints.sh
@@ -100,10 +100,7 @@ get_deployments() {
     	    json_deployments="$(echo "$json_deployments" | jq --arg clusterid "$clusterid_value" '{deployments: [.deployments[] | select(.clusterId == $clusterid)]}')"
         fi
     
-        ndeployment="$(echo $json_deployments | jq '.deployments | length')"
-        for ((i = 0; i < ndeployment; i = i + 1)); do
-            deployments+=("$(echo "$json_deployments" | jq .deployments[$i].id | tr -d '"')")
-        done
+	deployments=($(echo "$json_deployments" | jq -r '.deployments[].id'))
     else
         deployments=($deployment_value)
     fi


### PR DESCRIPTION
Currently turning the json with deployments to a list of deployments is slow, since the script loops through the deployments in the json one by one. Now all of the deployments are gotten in one step. The script is still slow in other places.