### PR TITLE
Create a policy to detect 'oc debug'

### DIFF
--- a/policies/oc-debug-runtime.json
+++ b/policies/oc-debug-runtime.json
@@ -24,7 +24,7 @@
             "policyVersion": "1.1",
             "policySections": [
                 {
-                    "sectionName": "Policy Section 1",
+                    "sectionName": "Shell detection",
                     "policyGroups": [
                         {
                             "fieldName": "Process Name",
@@ -32,7 +32,17 @@
                             "negate": false,
                             "values": [
                                 {
-                                    "value": ".*(sh).*"
+                                    "value": "^.*(sh)$"
+                                }
+                            ]
+                        },
+                        {
+                            "fieldName": "Process UID",
+                            "booleanOperator": "OR",
+                            "negate": false,
+                            "values": [
+                                {
+                                    "value": "0"
                                 }
                             ]
                         }

--- a/policies/oc-debug-runtime.json
+++ b/policies/oc-debug-runtime.json
@@ -1,0 +1,69 @@
+{
+    "policies": [
+        {
+            "id": "5a8a002d-ad68-4998-83cb-4de8cbb4903f",
+            "name": "Probable 'oc debug' access to pod",
+            "description": "Detect attempts to access pods using 'oc debug'",
+            "rationale": "'oc debug' can be used to access pod contents, potentially exposing sensitive data.",
+            "remediation": "Review OpenShift audit logs to verify the user, and investigate whether this was legitimate trouble-shooting or malicious activity.",
+            "disabled": false,
+            "categories": [
+                "Anomalous Activity"
+            ],
+            "lifecycleStages": [
+                "RUNTIME"
+            ],
+            "eventSource": "DEPLOYMENT_EVENT",
+            "exclusions": [],
+            "scope": [],
+            "severity": "HIGH_SEVERITY",
+            "enforcementActions": [],
+            "notifiers": [],
+            "SORTName": "",
+            "SORTLifecycleStage": "",
+            "SORTEnforcement": false,
+            "policyVersion": "1.1",
+            "policySections": [
+                {
+                    "sectionName": "Policy Section 1",
+                    "policyGroups": [
+                        {
+                            "fieldName": "Process Name",
+                            "booleanOperator": "OR",
+                            "negate": false,
+                            "values": [
+                                {
+                                    "value": ".*(sh).*"
+                                }
+                            ]
+                        },
+                        {
+                            "fieldName": "Privileged Container",
+                            "booleanOperator": "OR",
+                            "negate": false,
+                            "values": [
+                                {
+                                    "value": "true"
+                                }
+                            ]
+                        },
+                        {
+                            "fieldName": "Drop Capabilities",
+                            "booleanOperator": "OR",
+                            "negate": false,
+                            "values": [
+                                {
+                                    "value": "ALL"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "mitreAttackVectors": [],
+            "criteriaLocked": false,
+            "mitreVectorsLocked": false,
+            "isDefault": false
+        }
+    ]
+}

--- a/policies/oc-debug-runtime.json
+++ b/policies/oc-debug-runtime.json
@@ -1,8 +1,7 @@
 {
     "policies": [
         {
-            "id": "5a8a002d-ad68-4998-83cb-4de8cbb4903f",
-            "name": "Probable 'oc debug' access to pod",
+            "name": "Possible 'oc debug' access to pod",
             "description": "Detect attempts to access pods using 'oc debug'",
             "rationale": "'oc debug' can be used to access pod contents, potentially exposing sensitive data.",
             "remediation": "Review OpenShift audit logs to verify the user, and investigate whether this was legitimate trouble-shooting or malicious activity.",
@@ -34,26 +33,6 @@
                             "values": [
                                 {
                                     "value": ".*(sh).*"
-                                }
-                            ]
-                        },
-                        {
-                            "fieldName": "Privileged Container",
-                            "booleanOperator": "OR",
-                            "negate": false,
-                            "values": [
-                                {
-                                    "value": "true"
-                                }
-                            ]
-                        },
-                        {
-                            "fieldName": "Drop Capabilities",
-                            "booleanOperator": "OR",
-                            "negate": false,
-                            "values": [
-                                {
-                                    "value": "ALL"
                                 }
                             ]
                         }


### PR DESCRIPTION
Adds a new policy to detect attempts to access pods using `oc debug`. 

Note that `oc debug` doesn't invoke `kubectl exec` or similar commands to access the pod, instead creating a new `debug` pod configured the same as the original pod. For this reason we need to look at process activity inside pods (that look like `/bin/sh` or `/bin/bash`), and account for the ability of users to customise the shell via `oc debug --shell`.

Ideally we would distinguish this activity based on pod name or pod annotations like `debug.openshift.io/source-container`, but this is not currently possible for runtime policies. Instead we label this as "Possible oc debug activity", and guide users towards the OpenShift audit logs for validation.