### PR TITLE
add export2gitops utility

### DIFF
--- a/util-scripts/export2gitops/README.md
+++ b/util-scripts/export2gitops/README.md
@@ -1,0 +1,6 @@
+## export2gitops
+
+A python script that takes exported StackRox policies and converts them to StackRox SecurityPolicy objects, that can be managed with GitOps. 
+
+### Usage
+python export2gitops.py -i sample-policy.json -o netcat-in-image.yaml

--- a/util-scripts/export2gitops/export2gitops.py
+++ b/util-scripts/export2gitops/export2gitops.py
@@ -1,0 +1,51 @@
+import json
+import yaml
+import argparse
+
+def policy_to_yaml(json_file, yaml_file):
+    """Reads a JSON file, converts it to YAML, and writes it to an output file."""
+    # Read the JSON file
+    with open(json_file, "r") as file:
+        json_data = json.load(file)
+    
+    policies = json_data.get("policies", [])
+    yaml_policies = []
+
+    for policy in policies:
+        yaml_policy = {
+            "kind": "SecurityPolicy",
+            "apiVersion": "config.stackrox.io/v1alpha1",
+            "metadata": {
+                "name": policy["name"].lower().replace(" ", "-")
+            },
+            "spec": {
+                "policyName": policy["name"],
+                "categories": policy.get("categories", []),
+                "description": policy.get("description", ""),
+                "disabled": policy.get("disabled", False),
+                "remediation": policy.get("remediation", ""),
+                "lifecycleStages": policy.get("lifecycleStages", []),
+                "policySections": policy.get("policySections", []),
+                "rationale": policy.get("rationale", ""),
+                "severity": policy.get("severity", "LOW_SEVERITY")
+            }
+        }
+        yaml_policies.append(yaml_policy)
+
+    # Write to YAML file
+    with open(yaml_file, "w") as file:
+        yaml.dump_all(yaml_policies, file, default_flow_style=False, sort_keys=False)
+
+    print(f"✅ YAML output saved to {yaml_file}")
+
+if __name__ == "__main__":
+    # Set up argument parser
+    parser = argparse.ArgumentParser(description="Convert StackRox JSON exports to SecurityPolicy YAML")
+    parser.add_argument("-i", "--input", required=True, help="Path to the exported JSON file")
+    parser.add_argument("-o", "--output", required=True, help="Output file path")
+    
+    # Parse arguments
+    args = parser.parse_args()
+
+    # Convert the policy
+    policy_to_yaml(args.input, args.output)

--- a/util-scripts/export2gitops/sample-policy.json
+++ b/util-scripts/export2gitops/sample-policy.json
@@ -1,0 +1,52 @@
+{
+    "policies": [
+        {
+            "id": "98d3bbd9-7189-403a-bfe5-0af4033d4316",
+            "name": "Netcat in Image",
+            "description": "This policy checks for container images containing netcat ",
+            "rationale": "Netcat potentially allows attackers to move laterally, and access external services from a running pod",
+            "remediation": "Use the base image package manager to remove \"nmap-ncat\"",
+            "disabled": false,
+            "categories": [
+                "Package Management"
+            ],
+            "lifecycleStages": [
+                "BUILD",
+                "DEPLOY"
+            ],
+            "eventSource": "NOT_APPLICABLE",
+            "exclusions": [],
+            "scope": [],
+            "severity": "HIGH_SEVERITY",
+            "enforcementActions": [],
+            "notifiers": [],
+            "lastUpdated": "2025-01-30T20:45:47.172554064Z",
+            "SORTName": "",
+            "SORTLifecycleStage": "",
+            "SORTEnforcement": false,
+            "policyVersion": "1.1",
+            "policySections": [
+                {
+                    "sectionName": "Rule 1",
+                    "policyGroups": [
+                        {
+                            "fieldName": "Image Component",
+                            "booleanOperator": "OR",
+                            "negate": false,
+                            "values": [
+                                {
+                                    "value": "nmap-ncat="
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "mitreAttackVectors": [],
+            "criteriaLocked": false,
+            "mitreVectorsLocked": false,
+            "isDefault": false,
+            "source": "DECLARATIVE"
+        }
+    ]
+}


### PR DESCRIPTION
Adds a utility that converts exported StackRox policies to SecurityPolicy objects, that can be managed with GitOps.